### PR TITLE
Run os_floating_ip second time to actually get the value of FIP

### DIFF
--- a/tasks/bootstrap_server.yml
+++ b/tasks/bootstrap_server.yml
@@ -29,6 +29,12 @@
     reuse: yes
     network: "{{ external_network }}"
     server: "{{ openshift_cluster_id }}-bootstrap"
+  when:
+    - skip_attaching_bootstrap_fip is not defined
+
+- name: Get attached bootstrap server FIP
+  os_floating_ip:
+    server: "{{ openshift_cluster_id }}-bootstrap"
   register: result
   when:
     - skip_attaching_bootstrap_fip is not defined


### PR DESCRIPTION
OMG! WTF Ansible! When os_floating_ip module called for the first time it returns only ``changed: true``. When called for the second time it actually returns data (Attached FIP)!